### PR TITLE
fixed results ejs template field

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -18,7 +18,7 @@ app.get("/", (_, res) => {
 
 app.get("/results", async (req, res) => {
     res.render("results", {
-        results: [await Search(req.query.searchword)]
+        results: await Search(req.query.searchword)
     })
 })
 


### PR DESCRIPTION
old Search function return value had to be wrapped in an array before being handed over to the templating engine, now it returns an array. removed the brackets, so it works again